### PR TITLE
Add description to profile

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -37,6 +37,8 @@ params:
     profileMode:
         enabled: true
         title: Joe Doe
+        description: |
+          A minimalistic theme template for websites.
         imageUrl: "/images/profile.png"
         imageTitle: my image
         # imageWidth: 120

--- a/themes/charlolamode/assets/css/common/profile-mode.css
+++ b/themes/charlolamode/assets/css/common/profile-mode.css
@@ -41,3 +41,12 @@
 .button:active {
     transform: scale(0.96);
 }
+
+.profile-description {
+    margin: 8px;
+    color: var(--secondary);
+    font-size: 20px;
+    line-height: 1.6;
+    display: --webkit-box;
+    --webkit-box-orient: vertical
+}

--- a/themes/charlolamode/layouts/partials/index_profile.html
+++ b/themes/charlolamode/layouts/partials/index_profile.html
@@ -2,11 +2,11 @@
     {{- with .Site.Params.profileMode }}
     <div class="profile_inner">
         {{- if .imageUrl -}}
-        <img src="{{ .imageUrl | absURL }}" alt="{{ .imageTitle | default "profile image" }}"
+        <img src="{{ .imageUrl | absURL }}" alt="{{ .imageTitle | default " profile image" }}"
             height="{{ .imageHeight | default 150 }}" width="{{ .imageWidth | default 150 }}" />
         {{- end }}
         <h1>{{ .title | default $.Site.Title | markdownify }}</h1>
-        <span>{{ .subtitle | markdownify }}</span>
+        <div class="profile-description">{{ .description | markdownify }}</div>
         {{- partial "social_icons.html" $.Site.Params.socialIcons -}}
 
         {{- with .buttons }}
@@ -21,4 +21,3 @@
     </div>
     {{- end}}
 </div>
-


### PR DESCRIPTION
I'm using your personal website as a basis to build my own, and I've realized that the option to add a description in the main page is not available in the current version of the theme.

Since I know nothing about html or css, I used the web inspector to find differences between the css and html files of your website and those in this repo, and paired them. It seems to work fine!

The theme is lovely, and I appreciate the example comments in `config.yml`. Great job!