### PR TITLE
undo HTML escapes for post-meta

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -18,6 +18,6 @@
 {{- end }}
 
 {{- with ($scratch.Get "meta") }}
-{{- delimit . "&nbsp;·&nbsp;" -}}
+{{- delimit . "&nbsp;·&nbsp;" | safeHTML -}}
 {{- end -}}
 


### PR DESCRIPTION
Post meta needs to be unescaped to retain the HTML tags.